### PR TITLE
feat(zsh): add --help, 'all' and completions for git-bwt

### DIFF
--- a/zsh/.config/zsh/compdef.zsh
+++ b/zsh/.config/zsh/compdef.zsh
@@ -1,12 +1,21 @@
 #!/bin/zsh
 
 _sync_dots_autocomplete() {
-  local -a dirs
+  local -a items
   local repo_dir="$STOW_REPO"
+  local d
+
+  items=(
+    '--help:Show usage info'
+    'all:Sync every package directory in $STOW_REPO'
+  )
 
   # Get a list of directories under $STOW_REPO excluding .git and feed them into completion
-  dirs=(${(f)"$(fd --type d --max-depth 1 --exclude .git --base-directory $repo_dir --exec basename {})"})
-  _describe 'stow directories' dirs
+  for d in ${(f)"$(fd --type d --max-depth 1 --exclude .git --base-directory $repo_dir --exec basename {})"}; do
+    items+=("${d}:Sync ${d} configs")
+  done
+
+  _describe 'stow directories' items
 }
 
 compdef _sync_dots_autocomplete sync-dots
@@ -26,11 +35,31 @@ compdef _tv_autocomplete tv
 
 _build_autocomplete() {
   local -a targets
-  targets=(${(f)"$(build --list)"})
+  targets=(
+    '--help:Show usage info'
+    'all:Build every target'
+    'atuin:Build atuin from ~/Repositories/personal/atuin'
+    'lazygit:Build lazygit from ~/Repositories/personal/lazygit'
+    'television:Build television from ~/Repositories/personal/television'
+    'tmux:Build tmux from ~/Repositories/personal/tmux'
+  )
   _describe 'build targets' targets
 }
 
 compdef _build_autocomplete build
+
+_git_bwt_autocomplete() {
+  local -a items
+  if (( CURRENT == 2 )); then
+    items=(
+      '--help:Show usage info'
+    )
+    _describe 'git-bwt arguments' items
+  fi
+  # second positional arg is a free-form <remote-url>; no completion offered
+}
+
+compdef _git_bwt_autocomplete git-bwt
 
 # https://raw.githubusercontent.com/tmuxinator/tmuxinator/master/completion/tmuxinator.zsh
 _tmuxinator() {

--- a/zsh/.config/zsh/functions/git-bwt
+++ b/zsh/.config/zsh/functions/git-bwt
@@ -5,14 +5,18 @@
 # https://stackoverflow.com/questions/74862356/git-pull-doesnt-pull-latest-changes-when-using-git-worktree/74866544#comment132115905_74862356
 # Git [Bare] [W]ork[T]ree
 git-bwt () {
-  if [ -z "$1" ]; then
-    echo "Usage: git-bwt <remote-url>"
-    return 1
-  fi
+  case "$1" in
+    --help|"")
+      print "Usage: git-bwt <remote-url>"
+      return 0
+      ;;
+  esac
 
   local repo_url="$1"
   local repo_name=$(basename -s .git "$repo_url")
   local bare_repo_dir="${repo_name}.bwt"
+
+  print -P "\n%B%F{blue}======== Setting up $repo_name ========%f%b"
 
   echo "Cloning repository as bare: $repo_name..."
   git clone --bare "$repo_url" "$bare_repo_dir" || return 1

--- a/zsh/.config/zsh/functions/sync-dots
+++ b/zsh/.config/zsh/functions/sync-dots
@@ -1,14 +1,23 @@
 #!/bin/zsh
 
 sync-dots () {
-  # Fail fast if no argument
-  if [[ $# -eq 0 ]]; then
-    echo "Usage: sync-dots <dir>..." >&2
-    return 1
-  fi
-
   local target_dir="$HOME"
   local failed=0
+  local -a dirs
+
+  case "$1" in
+    --help|"")
+      print "Usage: sync-dots <dir>..."
+      print "       sync-dots all   # sync every package directory in \$STOW_REPO"
+      return 0
+      ;;
+    all)
+      dirs=(${(f)"$(fd --type d --max-depth 1 --exclude .git --base-directory $STOW_REPO --exec basename {})"})
+      ;;
+    *)
+      dirs=("$@")
+      ;;
+  esac
 
   # Ensure target exists
   mkdir -p "$target_dir" || return 1
@@ -16,9 +25,10 @@ sync-dots () {
   # Change to repo once
   z "$STOW_REPO" || return 1
 
-  for dir in "$@"; do
+  for dir in $dirs; do
     if [[ -d "$dir" ]]; then
-      stow "$dir" -t "$target_dir" || failed=1
+      print -P "\n%B%F{blue}======== Syncing $dir ========%f%b"
+      stow "$dir" -t "$target_dir" || { print -P "%F{red}==> Failed to sync $dir%f" >&2; failed=1; }
     else
       echo "Directory '$dir' does not exist in $STOW_REPO." >&2
       failed=1


### PR DESCRIPTION
- add --help handling and usage output to git-bwt and sync-dots
- add all option to sync-dots to sync every package dir from $STOW_REPO
- improve completions: add git-bwt, show help/all, and annotate build targets
- add clearer prints and error feedback during repo creation and sync