### PR TITLE
fix(nvim): prevent crashes and nil derefs across plugins

### DIFF
--- a/nvim/.config/nvim/lua/plugins/chrome/lualine/components/mode.lua
+++ b/nvim/.config/nvim/lua/plugins/chrome/lualine/components/mode.lua
@@ -23,7 +23,9 @@ end
 
 ---@param mode string
 function M.inverse_mode_hl(mode)
-  local c = mode_hl[mode]
+  -- Fallback for unmapped modes (e.g. terminal-normal 'NTERMINAL', insert-pending 'niI')
+  -- without this, an unmapped mode would crash the statusline on every redraw.
+  local c = mode_hl[mode] or mode_hl.NORMAL
   return { fg = c.bg, bg = c.fg, gui = c.gui }
 end
 

--- a/nvim/.config/nvim/lua/plugins/chrome/noice.nvim.lua
+++ b/nvim/.config/nvim/lua/plugins/chrome/noice.nvim.lua
@@ -132,14 +132,17 @@ return {
                 if not dropbar_timer then
                   dropbar_timer = vim.uv.new_timer()
                 end
-                dropbar_timer:stop()
-                dropbar_timer:start(
-                  100,
-                  0,
-                  vim.schedule_wrap(function()
-                    require('dropbar.utils.bar').exec('update')
-                  end)
-                )
+
+                if dropbar_timer then
+                  dropbar_timer:stop()
+                  dropbar_timer:start(
+                    100,
+                    0,
+                    vim.schedule_wrap(function()
+                      require('dropbar.utils.bar').exec('update')
+                    end)
+                  )
+                end
               end
 
               return false -- Don't match the condition for "opts"

--- a/nvim/.config/nvim/lua/plugins/core/lsp/nvim-lspconfig/lsp/eslint.lua
+++ b/nvim/.config/nvim/lua/plugins/core/lsp/nvim-lspconfig/lsp/eslint.lua
@@ -2,7 +2,8 @@ local eslint_registered = false
 
 return {
   opts = function()
-    local base_on_eslint_attach = vim.lsp.config.eslint.on_attach
+    local eslint_cfg = vim.lsp.config.eslint or {}
+    local base_on_eslint_attach = eslint_cfg.on_attach
 
     return {
       on_attach = function(client, bufnr)

--- a/nvim/.config/nvim/lua/plugins/core/lsp/nvim-lspconfig/lsp/vtsls.lua
+++ b/nvim/.config/nvim/lua/plugins/core/lsp/nvim-lspconfig/lsp/vtsls.lua
@@ -17,6 +17,83 @@ local js_config = ts_config
 
 return {
   setup = function()
+    -- Snacks.util.lsp.on already fires once per attaching client matching the filter,
+    -- so it must be registered at top level — nesting it inside LspAttach leaks watchers.
+    Snacks.util.lsp.on({ name = 'vtsls' }, function(_, client)
+      client.commands['_typescript.moveToFileRefactoring'] = function(command, _)
+        ---@type string, string, lsp.Range
+        local action, uri, range = unpack(command.arguments --[[@as any[] ]])
+
+        local function move(newf)
+          client:request('workspace/executeCommand', {
+            command = command.command,
+            arguments = { action, uri, range, newf },
+          })
+        end
+
+        local fname = vim.uri_to_fname(uri)
+        client:request('workspace/executeCommand', {
+          command = 'typescript.tsserverRequest',
+          arguments = {
+            'getMoveToRefactoringFileSuggestions',
+            {
+              file = fname,
+              startLine = range.start.line + 1,
+              startOffset = range.start.character + 1,
+              endLine = range['end'].line + 1,
+              endOffset = range['end'].character + 1,
+            },
+          },
+        }, function(_, result)
+          if not (result and result.body and result.body.files) then
+            return
+          end
+          ---@type string[]
+          local files = result.body.files
+          table.insert(files, 1, 'Enter new path...')
+          local cwd = vim.uv.cwd()
+          local home = vim.env.HOME
+
+          local function shorten_path(path)
+            local normalized = vim.fs.normalize(path)
+            local rel = cwd and vim.fs.relpath(cwd, normalized) or nil
+            local display = rel or normalized
+
+            if home and display:sub(1, #home) == home then
+              display = '~' .. display:sub(#home + 1)
+            end
+
+            return display
+          end
+
+          local function parent_dir(path)
+            local dir = vim.fs.dirname(path)
+            return dir and (dir:sub(-1) == '/' and dir or (dir .. '/')) or ''
+          end
+          vim.ui.select(files, {
+            prompt = 'Select move destination:',
+            format_item = function(f)
+              return shorten_path(f)
+            end,
+          }, function(f)
+            if f and f:find('^Enter new path') then
+              vim.ui.input({
+                prompt = 'Enter move destination:',
+                default = parent_dir(fname),
+                completion = 'file',
+              }, function(newf)
+                if newf then
+                  move(newf)
+                end
+              end)
+            elseif f then
+              move(f)
+            end
+          end)
+        end)
+      end
+    end)
+
     vim.api.nvim_create_autocmd('LspAttach', {
       group = vim.api.nvim_create_augroup('vtsls_lsp_attach', { clear = true }),
       callback = function(args)
@@ -46,78 +123,6 @@ return {
 
         map('<leader>cu', 'source.removeUnused.ts', 'Remove Unused Imports')
         map('<leader>ci', 'source.addMissingImports.ts', 'Add Missing Imports')
-
-        Snacks.util.lsp.on({ name = 'vtsls' }, function(_, client)
-          client.commands['_typescript.moveToFileRefactoring'] = function(command, _)
-            ---@type string, string, lsp.Range
-            local action, uri, range = unpack(command.arguments --[[@as any[] ]])
-
-            local function move(newf)
-              client:request('workspace/executeCommand', {
-                command = command.command,
-                arguments = { action, uri, range, newf },
-              })
-            end
-
-            local fname = vim.uri_to_fname(uri)
-            client:request('workspace/executeCommand', {
-              command = 'typescript.tsserverRequest',
-              arguments = {
-                'getMoveToRefactoringFileSuggestions',
-                {
-                  file = fname,
-                  startLine = range.start.line + 1,
-                  startOffset = range.start.character + 1,
-                  endLine = range['end'].line + 1,
-                  endOffset = range['end'].character + 1,
-                },
-              },
-            }, function(_, result)
-              ---@type string[]
-              local files = result.body.files
-              table.insert(files, 1, 'Enter new path...')
-              local cwd = vim.uv.cwd()
-              local home = vim.env.HOME
-
-              local function shorten_path(path)
-                local normalized = vim.fs.normalize(path)
-                local rel = cwd and vim.fs.relpath(cwd, normalized) or nil
-                local display = rel or normalized
-
-                if home and display:sub(1, #home) == home then
-                  display = '~' .. display:sub(#home + 1)
-                end
-
-                return display
-              end
-
-              local function parent_dir(path)
-                local dir = vim.fs.dirname(path)
-                return dir and (dir:sub(-1) == '/' and dir or (dir .. '/')) or ''
-              end
-              vim.ui.select(files, {
-                prompt = 'Select move destination:',
-                format_item = function(f)
-                  return shorten_path(f)
-                end,
-              }, function(f)
-                if f and f:find('^Enter new path') then
-                  vim.ui.input({
-                    prompt = 'Enter move destination:',
-                    default = parent_dir(fname),
-                    completion = 'file',
-                  }, function(newf)
-                    if newf then
-                      move(newf)
-                    end
-                  end)
-                elseif f then
-                  move(f)
-                end
-              end)
-            end)
-          end
-        end)
       end,
     })
   end,
@@ -130,7 +135,7 @@ return {
 
     -- PERF: Hardcode it for faster resolve time, since the version rarely changes anyway
     local mise_where =
-      '/Users/hareki/.local/share/mise/installs/npm-styled-typescript-styled-plugin/1'
+      vim.fn.expand('~/.local/share/mise/installs/npm-styled-typescript-styled-plugin/1')
     local plugin_root = mise_where
     -- mise where returns the tool root, packages are under lib/node_modules
     local npm_global_root = plugin_root ~= '' and (plugin_root .. '/lib/node_modules') or ''

--- a/nvim/.config/nvim/lua/plugins/features/editing/mini-ai/utils.lua
+++ b/nvim/.config/nvim/lua/plugins/features/editing/mini-ai/utils.lua
@@ -83,10 +83,10 @@ function M.whichkey(opts)
       local desc = obj.desc
 
       if prefix:sub(1, 1) == 'i' then
-        desc = desc:gsub(' with ws', '')
+        desc = desc:gsub(' with Ws', '')
       end
 
-      ret[#ret + 1] = { prefix .. obj[1], desc = obj.desc }
+      ret[#ret + 1] = { prefix .. obj[1], desc = desc }
     end
   end
   local which_key = require('which-key')


### PR DESCRIPTION
- lualine: fallback to NORMAL in inverse_mode_hl to avoid statusline crash
- noice: guard dropbar_timer nil before stop/start to prevent errors
- lsp: use vim.lsp.config.eslint or {} for on_attach; move vtsls Snacks.util.lsp.on to top-level to avoid LspAttach watcher leaks and add move-to-file-refactoring handler; expand mise path with vim.fn.expand instead of hardcoded string
- mini-ai: use computed desc for which-key entries so labels render correctly