### PR TITLE
refactor(nvim): unify utils requires and keymap helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-.DS_STORE
+.DS_Store
 bin/.local/bin/agent
 bin/.local/bin/cursor-agent

--- a/nvim/.config/nvim/lua/config/keymaps.lua
+++ b/nvim/.config/nvim/lua/config/keymaps.lua
@@ -13,6 +13,10 @@ local function diagnostic_goto(next, severity)
   end
 end
 
+local function style_enforcer()
+  return require('utils.formatters.async_style_enforcer')
+end
+
 -- Clean up Snacks keymaps picker a little
 for _, key in ipairs({
   ']a',
@@ -45,13 +49,11 @@ map({ 'n' }, '<Esc>', function()
 end, { desc = 'Clear Highlight' })
 
 map({ 'n', 'i' }, '<A-s>', function()
-  local enforcer = require('utils.formatters.async_style_enforcer')
-  enforcer.run()
+  style_enforcer().run()
 end, { desc = 'Format and Save' })
 
 map({ 'n', 'i' }, '<leader>F', function()
-  local enforcer = require('utils.formatters.async_style_enforcer')
-  enforcer.run({
+  style_enforcer().run({
     save = false,
   })
 end, { desc = 'Format' })
@@ -60,8 +62,7 @@ end, { desc = 'Format' })
 -- Test the keymap Neovim will receive with
 -- :echo keytrans(getcharstr())
 map({ 'n', 'i' }, '<F40>', function()
-  local enforcer = require('utils.formatters.async_style_enforcer')
-  enforcer.run_all()
+  style_enforcer().run_all()
 end, { desc = 'Format and Save All' })
 
 -- Mapped to Ctrl+Shift+W in ghostty config

--- a/nvim/.config/nvim/lua/plugins/core/lsp/nvim-lspconfig/lsp/vtsls.lua
+++ b/nvim/.config/nvim/lua/plugins/core/lsp/nvim-lspconfig/lsp/vtsls.lua
@@ -103,11 +103,10 @@ return {
           return
         end
 
-        ---@param lhs string
         ---@param action string
-        ---@param desc string
-        local function map(lhs, action, desc)
-          vim.keymap.set('n', lhs, function()
+        ---@return fun()
+        local function code_action(action)
+          return function()
             vim.lsp.buf.code_action({
               apply = true,
               context = {
@@ -115,14 +114,22 @@ return {
                 diagnostics = {},
               },
             })
-          end, {
+          end
+        end
+
+        ---@param mode string|string[]
+        ---@param lhs string
+        ---@param rhs string|function
+        ---@param desc string
+        local function map(mode, lhs, rhs, desc)
+          vim.keymap.set(mode, lhs, rhs, {
             buffer = args.buf,
             desc = 'TypeScript: ' .. desc,
           })
         end
 
-        map('<leader>cu', 'source.removeUnused.ts', 'Remove Unused Imports')
-        map('<leader>ci', 'source.addMissingImports.ts', 'Add Missing Imports')
+        map('n', '<leader>cu', code_action('source.removeUnused.ts'), 'Remove Unused Imports')
+        map('n', '<leader>ci', code_action('source.addMissingImports.ts'), 'Add Missing Imports')
       end,
     })
   end,

--- a/nvim/.config/nvim/lua/plugins/features/diagnostics/trouble.nvim.lua
+++ b/nvim/.config/nvim/lua/plugins/features/diagnostics/trouble.nvim.lua
@@ -51,24 +51,24 @@ return {
     end,
 
     opts = function()
-      local ui_utils = require('utils.ui')
+      local ui = require('utils.ui')
       local size_configs = require('config.size')
       local picker_config = require('config.picker')
-      local preview_cols, preview_rows = ui_utils.compute_size(size_configs.side_preview.md)
-      local panel_cols, _ = ui_utils.compute_size(size_configs.side_panel.md)
+      local preview_cols, preview_rows = ui.compute_size(size_configs.side_preview.md)
+      local panel_cols, _ = ui.compute_size(size_configs.side_panel.md)
       local preview_width_offset = panel_cols + preview_cols + 3
       local preview_height_offset = math.floor((vim.o.lines - preview_rows) / 2) - 1
 
       local function toggle_focus()
-        local previewManager = require('trouble.view.preview')
-        local preview = previewManager.preview
+        local preview_manager = require('trouble.view.preview')
+        local preview = preview_manager.preview
 
-        if not previewManager.is_open() or not preview then
+        if not preview_manager.is_open() or not preview then
           return
         end
 
-        local function map(key, callback, desc)
-          vim.keymap.set('n', key, callback, { buffer = preview.buf, desc = desc })
+        local function map(mode, lhs, rhs, desc)
+          vim.keymap.set(mode, lhs, rhs, { buffer = preview.buf, desc = desc })
         end
 
         local trouble_win = vim.api.nvim_get_current_win()
@@ -76,13 +76,13 @@ return {
         local common = require('utils.common')
         common.focus_win(preview.win)
 
-        map('<Tab>', function()
+        map('n', '<Tab>', function()
           if vim.api.nvim_win_is_valid(trouble_win) then
             common.focus_win(trouble_win)
           end
         end, 'Focus Trouble Window')
 
-        map('<CR>', function()
+        map('n', '<CR>', function()
           local trouble_view = require('trouble.view')
           local first_view = trouble_view.get({ open = true })[1]
           if first_view and preview.item then
@@ -90,7 +90,7 @@ return {
           end
         end, 'Jump to Item')
 
-        map('q', function()
+        map('n', 'q', function()
           if vim.api.nvim_win_is_valid(trouble_win) then
             common.focus_win(trouble_win)
           end

--- a/nvim/.config/nvim/lua/plugins/features/editing/flash.nvim.lua
+++ b/nvim/.config/nvim/lua/plugins/features/editing/flash.nvim.lua
@@ -1,8 +1,5 @@
 return {
   'folke/flash.nvim',
-  ---@type Flash.Config
-  opts = {},
-
   keys = {
     {
       'f',
@@ -48,7 +45,6 @@ return {
       end,
       desc = 'Treesitter Search',
     },
-    -- { '<C-s>', mode = { 'c' }, function() require('flash').toggle() end, desc = 'Toggle Flash Search', },
     -- Simulate nvim-treesitter incremental selection
     {
       '<C-Space>',
@@ -65,4 +61,6 @@ return {
       desc = 'Treesitter Incremental Selection',
     },
   },
+  ---@type Flash.Config
+  opts = {},
 }

--- a/nvim/.config/nvim/lua/plugins/features/git/gitsigns/init.lua
+++ b/nvim/.config/nvim/lua/plugins/features/git/gitsigns/init.lua
@@ -76,8 +76,8 @@ return {
         on_attach = function(buffer)
           local gs = package.loaded.gitsigns
 
-          local function map(mode, l, r, desc)
-            vim.keymap.set(mode, l, r, { buffer = buffer, desc = desc, silent = true })
+          local function map(mode, lhs, rhs, desc)
+            vim.keymap.set(mode, lhs, rhs, { buffer = buffer, desc = desc, silent = true })
           end
 
           map('n', ']h', function()
@@ -118,7 +118,7 @@ return {
           map('n', '<leader>hD', function()
             gs.diffthis('~')
           end, 'Diff This ~')
-          map({ 'o', 'x' }, 'ih', ':<C-U>Gitsigns select_hunk<CR>', 'GitSigns Select Hunk')
+          map({ 'o', 'x' }, 'ih', '<cmd>Gitsigns select_hunk<cr>', 'Gitsigns Select Hunk')
 
           map('n', '<leader>hb', function()
             local gitsigns = require('gitsigns')

--- a/nvim/.config/nvim/lua/plugins/features/navigation/nvim-tree/init.lua
+++ b/nvim/.config/nvim/lua/plugins/features/navigation/nvim-tree/init.lua
@@ -110,8 +110,8 @@ return {
           local size_configs = require('config.size')
 
           local side_preview = size_configs.side_preview
-          local size_utils = require('utils.ui')
-          local size = size_utils.popup_config(tree.state.size)
+          local ui = require('utils.ui')
+          local size = ui.popup_config(tree.state.size)
 
           -- We need to fill the missing row if the total height is an odd number
           -- (we can't have equal height for both windows)
@@ -124,7 +124,7 @@ return {
             }
           end
 
-          local preview_cols, preview_rows = size_utils.compute_size(side_preview.md)
+          local preview_cols, preview_rows = ui.compute_size(side_preview.md)
 
           return {
             width = preview_cols,
@@ -164,12 +164,11 @@ return {
     end,
 
     opts = function()
-      local ui_utils = require('utils.ui')
+      local ui = require('utils.ui')
       local size_configs = require('config.size')
       local tree = require('plugins.features.navigation.nvim-tree.utils')
       local state = tree.state
       local picker_config = require('config.picker')
-      local nvim_tree_utils = require('plugins.features.navigation.nvim-tree.utils')
 
       state.opts = {
         hijack_cursor = true, -- Keep cursor on the first letter of filename
@@ -267,15 +266,15 @@ return {
           side = 'right',
           -- Width when not in float mode
           width = function()
-            local panel_cols = ui_utils.compute_size(size_configs.side_panel.md)
+            local panel_cols = ui.compute_size(size_configs.side_panel.md)
             return panel_cols
           end,
 
           float = {
-            enable = nvim_tree_utils.state.position == 'float',
+            enable = state.position == 'float',
             quit_on_focus_loss = false,
             open_win_config = function()
-              local size = ui_utils.popup_config(tree.state.size)
+              local size = ui.popup_config(tree.state.size)
               local window_w = size.width
               local window_h = math.floor(size.height / 2)
               local col = size.col

--- a/nvim/.config/nvim/lua/plugins/features/navigation/nvim-tree/utils.lua
+++ b/nvim/.config/nvim/lua/plugins/features/navigation/nvim-tree/utils.lua
@@ -97,12 +97,12 @@ function M.create_node_action(folder_action)
 
     --- api.tree.get_node_under_cursor can return nvim_tree.api.DirectoryNode. Which contains `open` field
     ---@diagnostic disable-next-line: undefined-field
-    local nodeOpen = node.open
+    local node_open = node.open
 
     if
       folder_action == 'toggle'
-      or folder_action == 'expand' and not nodeOpen
-      or folder_action == 'collapse' and nodeOpen
+      or folder_action == 'expand' and not node_open
+      or folder_action == 'collapse' and node_open
     then
       api.node.open.edit()
     end
@@ -145,13 +145,13 @@ function M.toggle_tree_height(action)
     return
   end
 
-  local ui_utils = require('utils.ui')
-  local size = ui_utils.popup_config(M.state.size)
+  local ui = require('utils.ui')
+  local size = ui.popup_config(M.state.size)
   local window_h = math.floor(size.height / 2)
   local half_height = window_h - 1 -- Minus 1 for the space between the two windows
 
   -- Have to add one extra row if the total height is an odd number to fill out the entire popup size
-  local offset = ui_utils.popup_config(M.state.size).height % 2 == 0 and 0 or 1
+  local offset = size.height % 2 == 0 and 0 or 1
   local full_height = window_h * 2 + offset
 
   local cfg = vim.api.nvim_win_get_config(tree_win)

--- a/nvim/.config/nvim/lua/plugins/features/navigation/telescope/init.lua
+++ b/nvim/.config/nvim/lua/plugins/features/navigation/telescope/init.lua
@@ -65,12 +65,12 @@ return {
         -- 1. Collapse the blank row between *prompt* and *results*
         layout.results.line = layout.results.line - 1
         layout.results.height = layout.results.height + 1
-        local ui_utils = require('utils.ui')
+        local ui = require('utils.ui')
 
         -- 2. Seems like telescope.nvim exclude the statusline when centering the layout,
         -- Which is different from our logic in `size_utils.get_float_config('lg')`
         -- So we need to adjust/shift the position if needed
-        local target_row = ui_utils.popup_config(size, true).row
+        local target_row = ui.popup_config(size, true).row
         -- The top most component is the prompt window, so we use it as the anchor to adjust the position
         local top_line = layout.prompt.line
 
@@ -96,6 +96,7 @@ return {
         local actions_state = require('telescope.actions.state')
         local telescope_state = require('telescope.state')
         local cursorline = require('services.cursorline')
+        local common = require('utils.common')
 
         local picker = actions_state.get_current_picker(prompt_bufnr)
         local prompt_win = picker.prompt_win
@@ -104,7 +105,6 @@ return {
         local previewer_bufnr = previewer_winid and vim.api.nvim_win_get_buf(previewer_winid) or nil
 
         if not (previewer_winid and vim.api.nvim_win_is_valid(previewer_winid)) then
-          local common = require('utils.common')
           common.focus_win(prompt_win)
           return
         end
@@ -128,7 +128,6 @@ return {
         map('n', '<Tab>', function()
           restore_buf_state()
           set_cursorline(false, previewer_winid)
-          local common = require('utils.common')
           common.focus_win(prompt_win)
         end, 'Focus Prompt Window')
 
@@ -142,7 +141,6 @@ return {
           actions.select_default(prompt_bufnr)
         end, 'Select Default')
 
-        local common = require('utils.common')
         if common.focus_win(previewer_winid) then
           vim.schedule(function()
             set_cursorline(true, previewer_winid)


### PR DESCRIPTION
- extract style_enforcer() and replace inline requires in keymaps
- normalize map signatures to (mode, lhs, rhs, desc) and add code_action()
- standardize utils.ui to local ui and call compute_size/popup_config
- fix .gitignore casing and gitsigns select_hunk invocation
- move flash.nvim opts to keep keys and options grouped