### PR TITLE
fix(nvim): perf issues and bugs from codebase audit

### DIFF
--- a/nvim/.config/nvim/lua/chrome/dropbar-nvim/init.lua
+++ b/nvim/.config/nvim/lua/chrome/dropbar-nvim/init.lua
@@ -73,10 +73,10 @@ return {
           enable = dropbar_utils.enable,
           truncate = false,
           hover = true,
-          sources = function(buf, _)
+          sources = function(buf, win)
             -- Some ft/bt can slip through the enable check because their ft/bt are set later (E.g. grug-far)
             if dropbar_utils.is_ignored_filetype(buf) or dropbar_utils.is_ignored_buftype(buf) then
-              vim.wo.winbar = ''
+              vim.wo[win].winbar = ''
               return {}
             end
 
@@ -114,8 +114,8 @@ return {
             local utils = require('dropbar.utils')
 
             local custom_path = {
-              get_symbols = function(b, win, cursor)
-                local syms = sources.path.get_symbols(b, win, cursor)
+              get_symbols = function(b, w, cursor)
+                local syms = sources.path.get_symbols(b, w, cursor)
                 local start_idx = math.max(1, #syms - path_item_limit + 1)
                 local sliced = {}
                 if start_idx <= #syms then
@@ -126,7 +126,7 @@ return {
                 if #sliced > 0 then
                   -- Set a different highlight group for the last item (the file name) to avoid affecting other places
                   local last = sliced[#sliced]
-                  local hl = (win == vim.api.nvim_get_current_win()) and 'DropBarKindFileBar'
+                  local hl = (w == vim.api.nvim_get_current_win()) and 'DropBarKindFileBar'
                     or 'DropBarKindFileBarNC'
                   last.name_hl = hl
                 end

--- a/nvim/.config/nvim/lua/chrome/lualine-nvim/components/diagnostics.lua
+++ b/nvim/.config/nvim/lua/chrome/lualine-nvim/components/diagnostics.lua
@@ -10,4 +10,32 @@ M.symbols = {
 
 M.sections = { 'error', 'warn', 'info' }
 
+local SEVERITY_NAMES = {
+  [vim.diagnostic.severity.ERROR] = 'error',
+  [vim.diagnostic.severity.WARN] = 'warn',
+  [vim.diagnostic.severity.INFO] = 'info',
+  [vim.diagnostic.severity.HINT] = 'hint',
+}
+
+--- Count diagnostics for the current buffer, excluding the synthetic
+--- 'underline-hack' duplicates injected by diagnostic_underline_hack so
+--- they don't inflate the displayed counts.
+--- @return { error: integer, warn: integer, info: integer, hint: integer }
+local function filtered_counts()
+  local counts = { error = 0, warn = 0, info = 0, hint = 0 }
+
+  for _, diagnostic in ipairs(vim.diagnostic.get(0)) do
+    if diagnostic.source ~= 'underline-hack' then
+      local name = SEVERITY_NAMES[diagnostic.severity]
+      if name then
+        counts[name] = counts[name] + 1
+      end
+    end
+  end
+
+  return counts
+end
+
+M.sources = { filtered_counts }
+
 return M

--- a/nvim/.config/nvim/lua/chrome/lualine-nvim/components/snacks_image.lua
+++ b/nvim/.config/nvim/lua/chrome/lualine-nvim/components/snacks_image.lua
@@ -36,6 +36,14 @@ function M.cond()
     return mermaid_has_content(buf)
   end
 
+  -- Skip buffers whose language has no snacks `images` query (json, yaml, help, ...):
+  -- nothing can match there, so don't pay the per-cursor-move treesitter work below.
+  -- query.get is memoized by Neovim, so this is a table lookup after the first call.
+  local lang = vim.treesitter.language.get_lang(ft)
+  if not lang or not vim.treesitter.query.get(lang, 'images') then
+    return false
+  end
+
   local tick = vim.api.nvim_buf_get_changedtick(buf)
   local cursor = vim.api.nvim_win_get_cursor(0)
   local row, col = cursor[1], cursor[2]

--- a/nvim/.config/nvim/lua/chrome/lualine-nvim/init.lua
+++ b/nvim/.config/nvim/lua/chrome/lualine-nvim/init.lua
@@ -75,6 +75,7 @@ return {
         type = 'secondary-right',
         symbols = diagnostics.symbols,
         sections = diagnostics.sections,
+        sources = diagnostics.sources,
       }),
       create_wrapper({
         comp = tab.get,

--- a/nvim/.config/nvim/lua/core/lsp/nvim-lspconfig/lsp/eslint.lua
+++ b/nvim/.config/nvim/lua/core/lsp/nvim-lspconfig/lsp/eslint.lua
@@ -1,4 +1,5 @@
 local eslint_registered = false
+local wrapped_clients = {} --- @type table<integer, true>
 
 return {
   opts = function()
@@ -33,6 +34,13 @@ return {
         if not client or client.name ~= 'eslint' then
           return
         end
+
+        -- LspAttach fires once per (client, buffer) pair; wrap the shared
+        -- client's handlers only once or they'd nest on every buffer attach
+        if wrapped_clients[client.id] then
+          return
+        end
+        wrapped_clients[client.id] = true
 
         client:notify('$/setTrace', { value = 'verbose' }) -- Ask server to emit trace
 

--- a/nvim/.config/nvim/lua/features/diagnostics/eagle-nvim/utils/pretty-ts-errors.lua
+++ b/nvim/.config/nvim/lua/features/diagnostics/eagle-nvim/utils/pretty-ts-errors.lua
@@ -3,6 +3,7 @@ local M = {}
 
 M.state = {
   executable_path = 'pretty-ts-errors-markdown',
+  cli_unavailable = false, -- Set on spawn failure so we never re-pay a failed spawn
   max_cache_entries = 512,
   cache = {}, -- key -> { value, hits }
   cache_size = 0,
@@ -129,13 +130,33 @@ local function cache_set(key, value)
 end
 
 local function run_cli(input_object)
+  if M.state.cli_unavailable then
+    return nil
+  end
+
   local json_text = vim.json.encode(input_object)
   local exe = M.state.executable_path
-  local res = vim.system({ exe, '-i', json_text }, { text = true }):wait()
+
+  -- vim.system throws on spawn failure (e.g. the CLI is not installed);
+  -- fall back to the raw diagnostic message instead of breaking the popup.
+  local ok, res = pcall(function()
+    return vim.system({ exe, '-i', json_text }, { text = true }):wait()
+  end)
+  if not ok then
+    M.state.cli_unavailable = true
+    return nil
+  end
   if res and res.code == 0 and res.stdout and #res.stdout > 0 then
     return trim_trailing_whitespace(res.stdout)
   end
-  local res2 = vim.system({ exe }, { text = true, stdin = json_text }):wait()
+
+  local ok2, res2 = pcall(function()
+    return vim.system({ exe }, { text = true, stdin = json_text }):wait()
+  end)
+  if not ok2 then
+    M.state.cli_unavailable = true
+    return nil
+  end
   if res2 and res2.code == 0 and res2.stdout and #res2.stdout > 0 then
     return trim_trailing_whitespace(res2.stdout)
   end

--- a/nvim/.config/nvim/lua/features/diagnostics/trouble-nvim.lua
+++ b/nvim/.config/nvim/lua/features/diagnostics/trouble-nvim.lua
@@ -100,6 +100,14 @@ return {
         auto_refresh = false,
         win = { position = 'right', size = panel_cols },
 
+        modes = {
+          diagnostics = {
+            -- Hide the synthetic empty-message duplicates injected by
+            -- diagnostic_underline_hack for underline styling
+            filter = { ['not'] = { source = 'underline-hack' } },
+          },
+        },
+
         icons = {
           folder_closed = Conf.Icons.file_tree.folder,
           folder_open = Conf.Icons.file_tree.folder_empty_open,

--- a/nvim/.config/nvim/lua/features/search/visimatch-nvim.lua
+++ b/nvim/.config/nvim/lua/features/search/visimatch-nvim.lua
@@ -4,7 +4,7 @@ return {
     vim.api.nvim_create_autocmd('ModeChanged', {
       group = vim.api.nvim_create_augroup('search.visimatch.lazy_load', { clear = true }),
       desc = 'Load Visimatch in Visual Mode',
-      pattern = { '*:v', '*:V' }, -- v, V, <C-v>
+      pattern = '*:[vV\22]*', -- v, V, <C-v> (\22 is the raw CTRL-V byte)
       once = true,
       callback = function()
         local lazy = require('lazy')

--- a/nvim/.config/nvim/lua/utils/git.lua
+++ b/nvim/.config/nvim/lua/utils/git.lua
@@ -182,8 +182,13 @@ function M.get_repo_name()
   -- Get toplevel to determine if we're in the same repo
   local toplevel = M.exec_cmd('rev-parse --show-toplevel')
 
-  -- Check if we're still in the same repo (same toplevel) and cache is recent
-  if repo_cache.name and repo_cache.toplevel == toplevel then
+  -- Check if we're still in the same repo (same toplevel) and cache is recent.
+  -- Refresh last_cwd so subsequent calls from this cwd hit the fast path above
+  -- instead of re-spawning git on every statusline redraw. Require a non-nil
+  -- toplevel: outside a repo, nil == nil would return a stale name from a
+  -- previously visited directory.
+  if repo_cache.name and toplevel and repo_cache.toplevel == toplevel then
+    repo_cache.last_cwd = current_cwd
     return repo_cache.name
   end
 


### PR DESCRIPTION
## Summary

Full audit of the Neovim config (139 Lua files) for performance issues and potential bugs. Every finding below was verified against the actual source before fixing, including installed plugin internals (nvim-tree `view.lua`, nvim-tree-preview `manager.lua`, snacks `image/doc.lua`). Fixes are real logic corrections, not defensive guard spam.

## Changes and reasons

### 1. `utils/git.lua`: blocking git spawn on every statusline redraw after a cwd change

`get_repo_name()` runs on every lualine redraw. Its second fast path returned the cached name without updating `repo_cache.last_cwd`, so after any `:cd`/`:lcd` within the same repo the primary fast path missed forever and a synchronous `git rev-parse --show-toplevel` (`vim.system():wait()`, roughly 5-20ms of main-thread stall) ran on every redraw, sticky until cwd returned to the exact cached path. The fast path now refreshes `last_cwd`.

Same branch had a second defect: outside a git repo `toplevel` is nil, and `nil == nil` matched the cache, so moving between two different non-git directories kept returning the previous directory's name. The fast return now requires a non-nil toplevel.

### 2. `core/lsp/nvim-lspconfig/lsp/eslint.lua`: log handlers stacked once per buffer attach

`LspAttach` fires once per (client, buffer) pair, but the callback mutated the shared client object each time: it re-wrapped `client.handlers['$/logTrace']` and `window/logMessage` (capturing the previous wrapper) and allocated a fresh 200-entry store. After opening N eslint buffers: N nested wrappers, O(N) work per log message, N retained stores, and `:EslintLog` only showed the newest store. Now guarded per client id (mirrors the existing `eslint_registered` pattern); `:EslintRestart` still gets a fresh wrap since the new client has a new id.

### 3. `eagle-nvim/utils/pretty-ts-errors.lua`: popup errored when the CLI is missing

`vim.system` throws on spawn failure (ENOENT), so on a machine without `pretty-ts-errors-markdown` installed the whole eagle diagnostics popup errored instead of showing the raw message. Spawns are now pcall'd; on failure `cli_unavailable` is latched so a failed spawn is never re-paid, and the caller's existing fallback to `diagnostic.message` kicks in.

### 4. `visimatch-nvim.lua`: lazy load never triggered from visual-block

The `ModeChanged` pattern `{ '*:v', '*:V' }` claimed to cover `<C-v>`, but visual-block's mode string is the raw CTRL-V byte (`\22`), not `V`. With `once = true`, entering visual-block as the first visual action consumed nothing and the plugin stayed unloaded. Now `'*:[vV\22]*'`.

### 5. `lualine` + `trouble`: synthetic underline-hack diagnostics leaked into UI

`diagnostic_underline_hack` intentionally injects empty-message duplicate diagnostics (source `underline-hack`) so unnecessary-tagged diagnostics get both fading and an underline. Eagle already filtered them and signs are visually identical, but lualine's builtin `diagnostics` counted them (inflated warn/error counts) and Trouble listed them as empty rows. Added a filtered counting source for lualine and a `['not'] = { source = 'underline-hack' }` filter for Trouble's diagnostics mode.

### 6. `lualine-nvim/components/snacks_image.lua`: treesitter work on every cursor move in every buffer

The component's cache is keyed on cursor column, so every cursor movement was a miss that called `Snacks.image.doc.at_cursor` (treesitter parse plus `images` query iteration) in all parser-backed buffers, including ones where no image can ever match (json, yaml, help, ...). Added an early exit when the buffer's language has no snacks `images` query; `vim.treesitter.query.get` is memoized so the gate is a table lookup after the first call. Behavior is unchanged in languages snacks ships queries for.

### 7. `dropbar-nvim/init.lua`: winbar cleared on the wrong window

`sources = function(buf, _)` discarded the target window and set `vim.wo.winbar = ''` on the current window, so evaluating sources for a non-current window could blank the wrong window's winbar. Now uses the passed `win` via `vim.wo[win].winbar`. Also renamed the inner `get_symbols` parameter to `w` to avoid shadowing.

## Verification

- `stylua --check` passes on all changed files
- 13/13 headless functional tests pass: git cache spawns exactly once per cwd change and is re-armed afterwards; no stale name across non-git dirs; missing CLI returns the raw message with `cli_unavailable` latched; the ModeChanged pattern matches `v`/`V`/`<C-v>` and not `i`; lualine counts exclude the phantoms; json buffers skip `at_cursor` entirely while markdown still triggers it; trouble accepts the mode filter
- Full config boots cleanly headless (exit 0, no startup errors)

Left for interactive verification: `:EslintLog` capture across several JS/TS buffers in a real eslint project, and the dropbar winbar behavior with grug-far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)